### PR TITLE
chore(): runner refactoring

### DIFF
--- a/plugin-debezium-mysql/src/test/java/io/kestra/plugin/debezium/mysql/TriggerTest.java
+++ b/plugin-debezium-mysql/src/test/java/io/kestra/plugin/debezium/mysql/TriggerTest.java
@@ -5,12 +5,12 @@ import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
 import io.kestra.core.runners.FlowListeners;
-import io.kestra.core.runners.Worker;
 import io.kestra.scheduler.AbstractScheduler;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.jdbc.runner.JdbcScheduler;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.debezium.AbstractDebeziumTest;
+import io.kestra.worker.DefaultWorker;
 import io.micronaut.context.ApplicationContext;
 import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
@@ -70,7 +70,7 @@ class TriggerTest extends AbstractDebeziumTest {
                 this.applicationContext,
                 this.flowListenersService
             );
-            Worker worker = applicationContext.createBean(Worker.class, IdUtils.create(), 8, null);
+            DefaultWorker worker = applicationContext.createBean(DefaultWorker.class, IdUtils.create(), 8, null);
         ) {
             // wait for execution
             Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {

--- a/plugin-debezium-mysql/src/test/resources/flows/realtime.yaml
+++ b/plugin-debezium-mysql/src/test/resources/flows/realtime.yaml
@@ -12,6 +12,8 @@ triggers:
     password: mysql_passwd
     includedTables:
       - kestra.realtime_events
+    properties:
+      offset.storage: org.apache.kafka.connect.storage.MemoryOffsetBackingStore
 
 tasks:
   - id: end

--- a/plugin-debezium-mysql/src/test/resources/flows/trigger.yaml
+++ b/plugin-debezium-mysql/src/test/resources/flows/trigger.yaml
@@ -14,6 +14,8 @@ triggers:
     maxWait: 30
     includedTables:
       - kestra.trigger_events
+    properties:
+      offset.storage: org.apache.kafka.connect.storage.MemoryOffsetBackingStore
 
 tasks:
   - id: end

--- a/plugin-debezium-sqlserver/src/test/resources/flows/realtime.yaml
+++ b/plugin-debezium-sqlserver/src/test/resources/flows/realtime.yaml
@@ -12,6 +12,8 @@ triggers:
     snapshotMode: INITIAL_ONLY
     properties:
       database.encrypt: false
+      offset.storage: org.apache.kafka.connect.storage.MemoryOffsetBackingStore
+      database.history: io.debezium.relational.history.MemoryDatabaseHistory
     includedTables:
       - dbo.events
 

--- a/plugin-debezium-sqlserver/src/test/resources/flows/trigger.yaml
+++ b/plugin-debezium-sqlserver/src/test/resources/flows/trigger.yaml
@@ -13,6 +13,8 @@ triggers:
     snapshotMode: INITIAL_ONLY
     properties:
       database.encrypt: false
+      offset.storage: org.apache.kafka.connect.storage.MemoryOffsetBackingStore
+      database.history: io.debezium.relational.history.MemoryDatabaseHistory
     includedTables:
       - dbo.events
 


### PR DESCRIPTION
### Breaking Change
#### Debezium plugin now, requires explicit offset storage configuration
Add to existing Debezium triggers:
```yaml
properties:
  offset.storage: org.apache.kafka.connect.storage.MemoryOffsetBackingStore
  database.history: io.debezium.relational.history.MemoryDatabaseHistory
  ```