### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/plugin-debezium-db2/src/main/java/io/kestra/plugin/debezium/db2/Capture.java
+++ b/plugin-debezium-db2/src/main/java/io/kestra/plugin/debezium/db2/Capture.java
@@ -16,6 +16,7 @@ import io.debezium.connector.db2.Db2Connector;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -57,6 +58,7 @@ import lombok.experimental.SuperBuilder;
 )
 public class Capture extends AbstractDebeziumTask implements Db2Interface {
 
+    @PluginProperty(group = "main")
     protected Property<String> database;
 
     @Builder.Default

--- a/plugin-debezium-db2/src/main/java/io/kestra/plugin/debezium/db2/Db2Interface.java
+++ b/plugin-debezium-db2/src/main/java/io/kestra/plugin/debezium/db2/Db2Interface.java
@@ -4,12 +4,14 @@ import io.kestra.core.models.property.Property;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface Db2Interface {
     @Schema(
         title = "The name of the DB2 database from which to stream the changes."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getDatabase();
 
     @Schema(
@@ -26,6 +28,7 @@ public interface Db2Interface {
             "- `RECOVERY`: Set this option to restore a database schema history topic that is lost or corrupted. After a restart, the connector runs a snapshot that rebuilds the topic from the source tables."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<SnapshotMode> getSnapshotMode();
 
     public enum SnapshotMode {

--- a/plugin-debezium-mongodb/src/main/java/io/kestra/plugin/debezium/mongodb/Capture.java
+++ b/plugin-debezium-mongodb/src/main/java/io/kestra/plugin/debezium/mongodb/Capture.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -99,11 +100,14 @@ import lombok.experimental.SuperBuilder;
 )
 public class Capture extends AbstractDebeziumTask implements MongodbInterface {
 
+    @PluginProperty(group = "advanced")
     private Object includedCollections;
 
+    @PluginProperty(group = "advanced")
     private Object excludedCollections;
 
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> connectionString;
 
     @Builder.Default

--- a/plugin-debezium-mongodb/src/main/java/io/kestra/plugin/debezium/mongodb/MongodbInterface.java
+++ b/plugin-debezium-mongodb/src/main/java/io/kestra/plugin/debezium/mongodb/MongodbInterface.java
@@ -15,6 +15,7 @@ public interface MongodbInterface {
             "mongodb://mongo_user:mongo_passwd@mongos0.example.com:27017,mongos1.example.com:27017/"
         }
     )
+    @PluginProperty(group = "connection")
     Property<String> getConnectionString();
 
     @Schema(
@@ -22,7 +23,7 @@ public interface MongodbInterface {
         description = "A list of regular expressions that match the collection namespaces (for example, <dbName>.<collectionName>) of all collections to be monitored",
         example = "inventory[.]*"
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Object getIncludedCollections();
 
     @Schema(
@@ -30,7 +31,7 @@ public interface MongodbInterface {
         description = "A list of regular expressions that match the collection namespaces (for example, <dbName>.<collectionName>) of all collections to be excluded",
         example = "inventory[.]*"
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Object getExcludedCollections();
 
     @Schema(
@@ -44,6 +45,7 @@ public interface MongodbInterface {
             "- `WHEN_NEEDED`: The connector runs a snapshot upon startup whenever it deems it necessary. That is, when no offsets are available, or when a previously recorded offset specifies a binlog location or GTID that is not available in the server."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<SnapshotMode> getSnapshotMode();
 
     public enum SnapshotMode {

--- a/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/Capture.java
+++ b/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/Capture.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -60,6 +61,7 @@ public class Capture extends AbstractDebeziumTask implements MysqlInterface {
     private Property<MysqlInterface.SnapshotMode> snapshotMode = Property.ofValue(SnapshotMode.INITIAL);
 
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> serverId;
 
     @Override

--- a/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/MysqlInterface.java
+++ b/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/MysqlInterface.java
@@ -27,6 +27,7 @@ public interface MysqlInterface {
             "- `RECOVERY`: Restores a database schema history topic that is lost or corrupted by rebuilding it from the source tables.\n"
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<SnapshotMode> getSnapshotMode();
 
     @Schema(
@@ -36,7 +37,7 @@ public interface MysqlInterface {
             "the binlog. By default, a random number between 5400 and 6400 is generated, though the recommendation " +
             "is to explicitly set a value."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Property<String> getServerId();
 
     public enum SnapshotMode {

--- a/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/Capture.java
+++ b/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/Capture.java
@@ -16,6 +16,7 @@ import io.debezium.connector.oracle.OracleConnector;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -77,10 +78,13 @@ import lombok.experimental.SuperBuilder;
 )
 public class Capture extends AbstractDebeziumTask implements OracleInterface {
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<SnapshotMode> snapshotMode = Property.ofValue(SnapshotMode.INITIAL);
 
+    @PluginProperty(group = "main")
     private Property<String> sid;
 
+    @PluginProperty(group = "connection")
     private Property<String> pluggableDatabase;
 
     @Override

--- a/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/OracleInterface.java
+++ b/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/OracleInterface.java
@@ -12,12 +12,14 @@ public interface OracleInterface {
         title = "The name of the database to capture changes from."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getSid();
 
     @Schema(
         title = "The name of the Oracle pluggable database that the connector captures changes from. Used in container database (CDB) installations only.",
         description = "For non-container database (non-CDB) installation, do not specify the pluggableDatabase property."
     )
+    @PluginProperty(group = "connection")
     Property<String> getPluggableDatabase();
 
     @Schema(
@@ -33,7 +35,7 @@ public interface OracleInterface {
             +
             "- `RECOVERY`: This is a recovery setting for a connector that has already been capturing changes. When you restart the connector, this setting enables recovery of a corrupted or lost database history topic. You might set it periodically to \"clean up\" a database history topic that has been growing unexpectedly. Database history topics require infinite retention."
     )
-    @PluginProperty(dynamic = false)
+    @PluginProperty(dynamic = false, group = "main")
     @NotNull
     Property<SnapshotMode> getSnapshotMode();
 

--- a/plugin-debezium-postgres/src/main/java/io/kestra/plugin/debezium/postgres/Capture.java
+++ b/plugin-debezium-postgres/src/main/java/io/kestra/plugin/debezium/postgres/Capture.java
@@ -15,6 +15,7 @@ import io.debezium.connector.postgresql.PostgresConnector;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -56,26 +57,34 @@ import lombok.experimental.SuperBuilder;
     }
 )
 public class Capture extends AbstractDebeziumTask implements PostgresInterface {
+    @PluginProperty(group = "main")
     protected Property<String> database;
 
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<PluginName> pluginName = Property.ofValue(PluginName.PGOUTPUT);
 
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<String> slotName = Property.ofValue("kestra");
 
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<String> publicationName = Property.ofValue("kestra_publication");
 
     @Builder.Default
     protected Property<PostgresInterface.SslMode> sslMode = Property.ofValue(SslMode.DISABLE);
 
+    @PluginProperty(group = "advanced")
     protected Property<String> sslRootCert;
 
+    @PluginProperty(group = "advanced")
     protected Property<String> sslCert;
 
+    @PluginProperty(group = "connection")
     protected Property<String> sslKey;
 
+    @PluginProperty(group = "connection")
     protected Property<String> sslKeyPassword;
 
     @Builder.Default

--- a/plugin-debezium-postgres/src/main/java/io/kestra/plugin/debezium/postgres/PostgresInterface.java
+++ b/plugin-debezium-postgres/src/main/java/io/kestra/plugin/debezium/postgres/PostgresInterface.java
@@ -4,12 +4,14 @@ import io.kestra.core.models.property.Property;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface PostgresInterface {
     @Schema(
         title = "The name of the PostgreSQL database from which to stream the changes."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getDatabase();
 
     @Schema(
@@ -21,6 +23,7 @@ public interface PostgresInterface {
             "connector a separate message for each change in a transaction."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<PluginName> getPluginName();
 
     @Schema(
@@ -34,6 +37,7 @@ public interface PostgresInterface {
             "uses the publication as it is defined."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getPublicationName();
 
     @Schema(
@@ -44,6 +48,7 @@ public interface PostgresInterface {
             "which state: \"Each replication slot has a name, which can contain lower-case letters, numbers, and the underscore character.\""
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getSlotName();
 
     @Schema(
@@ -55,29 +60,34 @@ public interface PostgresInterface {
             "- `VERIFY_FULL` behaves like verify-ca but also verifies that the server certificate matches the host to which the connector is trying to connect.\n\n" +
             "See the [PostgreSQL documentation](https://www.postgresql.org/docs/current/static/libpq-connect.html) for more information."
     )
+    @PluginProperty(group = "connection")
     Property<SslMode> getSslMode();
 
     @Schema(
         title = "The root certificate(s) against which the server is validated.",
         description = "Must be a PEM encoded certificate."
     )
+    @PluginProperty(group = "connection")
     Property<String> getSslRootCert();
 
     @Schema(
         title = "The SSL certificate for the client.",
         description = "Must be a PEM encoded certificate."
     )
+    @PluginProperty(group = "connection")
     Property<String> getSslCert();
 
     @Schema(
         title = "The SSL private key of the client.",
         description = "Must be a PEM encoded key."
     )
+    @PluginProperty(group = "connection")
     Property<String> getSslKey();
 
     @Schema(
         title = "The password to access the client private key `sslKey`."
     )
+    @PluginProperty(group = "connection")
     Property<String> getSslKeyPassword();
 
     @Schema(
@@ -90,6 +100,7 @@ public interface PostgresInterface {
             "- `INITIAL_ONLY`: The connector performs an initial snapshot and then stops, without processing any subsequent changes.\n"
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<SnapshotMode> getSnapshotMode();
 
     enum SnapshotMode {

--- a/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/Capture.java
+++ b/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/Capture.java
@@ -15,6 +15,7 @@ import io.debezium.connector.sqlserver.SqlServerConnector;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -54,6 +55,7 @@ import lombok.experimental.SuperBuilder;
     }
 )
 public class Capture extends AbstractDebeziumTask implements SqlServerInterface {
+    @PluginProperty(group = "main")
     protected Property<String> database;
 
     @Builder.Default

--- a/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/SqlServerInterface.java
+++ b/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/SqlServerInterface.java
@@ -10,12 +10,14 @@ import io.kestra.core.runners.RunContext;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface SqlServerInterface {
     @Schema(
         title = "The name of the Microsoft SQL Server database from which to stream the changes."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getDatabase();
 
     @Schema(
@@ -27,6 +29,7 @@ public interface SqlServerInterface {
             "- `SCHEMA_ONLY`: Takes a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics.\n"
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<SnapshotMode> getSnapshotMode();
 
     static void handleProperties(Properties properties, RunContext runContext, SqlServerInterface sqlServer) throws IllegalVariableEvaluationException, IOException {

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumInterface.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumInterface.java
@@ -33,6 +33,7 @@ public interface AbstractDebeziumInterface {
         title = "The name of deleted field if deleted is `ADD_FIELD`."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getDeletedFieldName();
 
     @Schema(
@@ -57,6 +58,7 @@ public interface AbstractDebeziumInterface {
         title = "The name of metadata field if metadata is `ADD_FIELD`."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getMetadataFieldName();
 
     @Schema(
@@ -74,81 +76,88 @@ public interface AbstractDebeziumInterface {
         description = "Ignore CREATE, ALTER, DROP and TRUNCATE operations."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<Boolean> getIgnoreDdl();
 
     @Schema(
         title = "Hostname of the remote server."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getHostname();
 
     @Schema(
         title = "Port of the remote server."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getPort();
 
     @Schema(
         title = "Username on the remote server."
     )
+    @PluginProperty(group = "connection")
     Property<String> getUsername();
 
     @Schema(
         title = "Password on the remote server."
     )
+    @PluginProperty(group = "connection")
     Property<String> getPassword();
 
     @Schema(
         title = "An optional, comma-separated list of regular expressions that match the names of the databases for which to capture changes.",
         description = "The connector does not capture changes in any database whose name is not in `includedDatabases`. By default, the connector captures changes in all databases. Do not also set the `excludedDatabases` connector configuration property."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Object getIncludedDatabases();
 
     @Schema(
         title = "An optional, comma-separated list of regular expressions that match the names of databases for which you do not want to capture changes.",
         description = "The connector captures changes in any database whose name is not in the `excludedDatabases`. Do not also set the `includedDatabases` connector configuration property."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Object getExcludedDatabases();
 
     @Schema(
         title = "An optional, comma-separated list of regular expressions that match fully-qualified table identifiers of tables whose changes you want to capture.",
         description = "The connector does not capture changes in any table not included in `includedTables`. Each identifier is of the form databaseName.tableName. By default, the connector captures changes in every non-system table in each database whose changes are being captured. Do not also specify the `excludedTables` connector configuration property."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Object getIncludedTables();
 
     @Schema(
         title = "An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you do not want to capture.",
         description = "The connector captures changes in any table not included in `excludedTables`. Each identifier is of the form databaseName.tableName. Do not also specify the `includedTables` connector configuration property."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Object getExcludedTables();
 
     @Schema(
         title = "An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event record values.",
         description = "Fully-qualified names for columns are of the form databaseName.tableName.columnName. Do not also specify the `excludedColumns` connector configuration property."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Object getIncludedColumns();
 
     @Schema(
         title = "An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to include in change event record values.",
         description = "Fully-qualified names for columns are of the form databaseName.tableName.columnName. Do not also specify the `includedColumns` connector configuration property.\""
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     Object getExcludedColumns();
 
     @Schema(
         title = "Additional configuration properties.",
         description = "Any additional configuration properties that is valid for the current driver."
     )
+    @PluginProperty(group = "advanced")
     Property<Map<String, String>> getProperties();
 
     @Schema(
         title = "The name of the Debezium state file stored in the KV Store for that namespace."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getStateName();
 }

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumRealtimeTrigger.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumRealtimeTrigger.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -109,6 +110,7 @@ public abstract class AbstractDebeziumRealtimeTrigger extends AbstractTrigger im
             """
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<OffsetCommitMode> offsetsCommitMode = Property.ofValue(OffsetCommitMode.ON_STOP);
 
     @Builder.Default
@@ -318,9 +320,11 @@ public abstract class AbstractDebeziumRealtimeTrigger extends AbstractTrigger im
     public static class StreamOutput implements io.kestra.core.models.tasks.Output {
 
         @Schema(title = "Stream.", description = "Stream source")
+        @PluginProperty(group = "advanced")
         private String stream;
 
         @Schema(title = "Data.", description = "Data extracted.")
+        @PluginProperty(group = "advanced")
         private Map<String, Object> data;
     }
 

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
@@ -110,20 +110,21 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
         title = "The maximum number of rows to fetch before stopping.",
         description = "It's not an hard limit and is evaluated every second."
     )
-    @PluginProperty
+    @PluginProperty(group = "execution")
     private Property<Integer> maxRecords;
 
     @Schema(
         title = "The maximum duration waiting for new rows.",
         description = "It's not an hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
     )
+    @PluginProperty(group = "execution")
     private Property<Duration> maxDuration;
 
     @Schema(
         title = "The maximum total processing duration.",
         description = "It's not an hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
     )
-    @PluginProperty
+    @PluginProperty(group = "execution")
     @Builder.Default
     private Property<Duration> maxWait = Property.ofValue(Duration.ofSeconds(10));
 
@@ -132,6 +133,7 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
         description = "It's not an hard limit and is evaluated every second.\n The properties 'maxRecord', 'maxDuration' and 'maxWait' are evaluated only after the snapshot is done."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<Duration> maxSnapshotDuration = Property.ofValue(Duration.ofHours(1));
 
     @Schema(

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTrigger.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTrigger.java
@@ -13,6 +13,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.plugin.debezium.AbstractDebeziumRealtimeTrigger.OffsetCommitMode;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -76,12 +77,14 @@ public abstract class AbstractDebeziumTrigger extends AbstractTrigger implements
         title = "The maximum number of rows to fetch before stopping.",
         description = "It's not an hard limit and is evaluated every second."
     )
+    @PluginProperty(group = "execution")
     protected Property<Integer> maxRecords;
 
     @Schema(
         title = "The maximum duration waiting for new rows.",
         description = "It's not an hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
     )
+    @PluginProperty(group = "execution")
     protected Property<Duration> maxDuration;
 
     @Schema(
@@ -89,6 +92,7 @@ public abstract class AbstractDebeziumTrigger extends AbstractTrigger implements
         description = "It's not an hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     protected Property<Duration> maxWait = Property.ofValue(Duration.ofSeconds(10));
 
     @Schema(
@@ -96,6 +100,7 @@ public abstract class AbstractDebeziumTrigger extends AbstractTrigger implements
         description = "It's not an hard limit and is evaluated every second.\n The properties 'maxRecord', 'maxDuration' and 'maxWait' are evaluated only after the snapshot is done."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     protected Property<Duration> maxSnapshotDuration = Property.ofValue(Duration.ofHours(1));
 
     @Schema(
@@ -106,5 +111,6 @@ public abstract class AbstractDebeziumTrigger extends AbstractTrigger implements
             """
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     protected Property<OffsetCommitMode> offsetsCommitMode = Property.ofValue(OffsetCommitMode.ON_STOP);
 }


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712