### PR TITLE
fix(build): fix Gradle 9.5 cross-project sourceSets access

### DIFF
--- a/plugin-debezium-db2/build.gradle
+++ b/plugin-debezium-db2/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 dependencies {
     implementation project(':plugin-debezium')
-    testImplementation project(':plugin-debezium').sourceSets.test.output
+    testImplementation project(path: ':plugin-debezium', configuration: 'testOutput')
 
     implementation group: 'com.ibm.db2.jcc', name: 'db2jcc', version: 'db2jcc4'
     // Solution to weird bug because of NoClassDefFoundError: com/ibm/db2/jcc/DB2Driver

--- a/plugin-debezium-mongodb/build.gradle
+++ b/plugin-debezium-mongodb/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 dependencies {
     implementation project(':plugin-debezium')
-    testImplementation project(':plugin-debezium').sourceSets.test.output
+    testImplementation project(path: ':plugin-debezium', configuration: 'testOutput')
 
     implementation group: 'io.debezium', name: 'debezium-connector-mongodb', version: debeziumVersion
 }

--- a/plugin-debezium-mysql/build.gradle
+++ b/plugin-debezium-mysql/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 dependencies {
     implementation project(':plugin-debezium')
-    testImplementation project(':plugin-debezium').sourceSets.test.output
+    testImplementation project(path: ':plugin-debezium', configuration: 'testOutput')
 
     implementation group: 'io.debezium', name: 'debezium-connector-mysql', version: debeziumVersion
 }

--- a/plugin-debezium-oracle/build.gradle
+++ b/plugin-debezium-oracle/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 dependencies {
     implementation project(':plugin-debezium')
-    testImplementation project(':plugin-debezium').sourceSets.test.output
+    testImplementation project(path: ':plugin-debezium', configuration: 'testOutput')
 
     implementation group: 'io.debezium', name: 'debezium-connector-oracle', version: debeziumVersion
 }

--- a/plugin-debezium-postgres/build.gradle
+++ b/plugin-debezium-postgres/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 dependencies {
     implementation project(':plugin-debezium')
-    testImplementation project(':plugin-debezium').sourceSets.test.output
+    testImplementation project(path: ':plugin-debezium', configuration: 'testOutput')
 
     api group: 'io.debezium', name: 'debezium-connector-postgres', version: debeziumVersion
     api 'org.bouncycastle:bcprov-jdk18on'

--- a/plugin-debezium-sqlserver/build.gradle
+++ b/plugin-debezium-sqlserver/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 dependencies {
     implementation project(':plugin-debezium')
-    testImplementation project(':plugin-debezium').sourceSets.test.output
+    testImplementation project(path: ':plugin-debezium', configuration: 'testOutput')
 
     implementation group: 'io.debezium', name: 'debezium-connector-sqlserver', version: debeziumVersion
 }

--- a/plugin-debezium/build.gradle
+++ b/plugin-debezium/build.gradle
@@ -16,3 +16,16 @@ dependencies {
     implementation group: 'io.debezium', name: 'debezium-api', version: debeziumVersion
     implementation group: 'io.debezium', name: 'debezium-embedded', version: debeziumVersion
 }
+
+configurations {
+    testOutput
+}
+
+task testJar(type: Jar) {
+    archiveClassifier = 'tests'
+    from sourceSets.test.output
+}
+
+artifacts {
+    testOutput testJar
+}


### PR DESCRIPTION
## Summary

- Gradle 9.5 no longer allows accessing `.sourceSets` on a `project()` call inside a `dependencies {}` block — it returns `DefaultProjectDependency`, not `Project`
- All 6 consumer submodules used `project(':plugin-debezium').sourceSets.test.output`, which breaks with Gradle 9.5
- Fix: expose `plugin-debezium` test classes as a `testJar` artifact under a named `testOutput` configuration; all consumers now reference it via `project(path: ':plugin-debezium', configuration: 'testOutput')`

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)