### PR TITLE
fix(build): increase Gradle heap and mark testOutput as consumable-only

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 version=1.4.1-SNAPSHOT
 kestraVersion=1.3.13
 debeziumVersion=3.3.1.Final
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m

--- a/plugin-debezium/build.gradle
+++ b/plugin-debezium/build.gradle
@@ -18,7 +18,10 @@ dependencies {
 }
 
 configurations {
-    testOutput
+    testOutput {
+        canBeResolved = false
+        canBeConsumed = true
+    }
 }
 
 task testJar(type: Jar) {


### PR DESCRIPTION
## Summary

- Add `org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m` to `gradle.properties` to fix OOM in the Automatic Dependency Submission workflow (`ForceDependencyResolutionPlugin_resolveProjectDependencies` was hitting the 512 MiB limit)
- Mark the `testOutput` configuration with `canBeResolved = false, canBeConsumed = true` — it is an outgoing configuration meant to be consumed by other submodules, not resolved locally; this also prevents `ForceDependencyResolutionPlugin` from unnecessarily resolving it

## Test plan

- [ ] Automatic Dependency Submission workflow no longer OOMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)