### PR TITLE
test: add sanity checks for all Debezium connectors

### DIFF
--- a/plugin-debezium-db2/src/test/java/io/kestra/plugin/debezium/db2/SanityChecks.java
+++ b/plugin-debezium-db2/src/test/java/io/kestra/plugin/debezium/db2/SanityChecks.java
@@ -1,0 +1,52 @@
+package io.kestra.plugin.debezium.db2;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.services.KVStoreService;
+import io.kestra.plugin.debezium.AbstractDebeziumTest;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest(startRunner = true)
+@Disabled("The tests are disabled for CI, as db2 container have long time initialization")
+class SanityChecks extends AbstractDebeziumTest {
+
+    @Inject
+    private KVStoreService kvStoreService;
+
+    @Override
+    protected String getUrl() {
+        return "jdbc:db2://localhost:5023/kestra";
+    }
+
+    @Override
+    protected String getUsername() {
+        return "db2inst1";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "password";
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        cleanupFlowState(kvStoreService, "sanitychecks.plugin-debezium-db2", "db2-capture", "debezium-state");
+        executeSqlScript("scripts/db2.sql");
+    }
+
+    @Test
+    @ExecuteFlow("sanity-checks/db2-capture.yaml")
+    void db2Capture(Execution execution) {
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+}

--- a/plugin-debezium-db2/src/test/resources/sanity-checks/db2-capture.yaml
+++ b/plugin-debezium-db2/src/test/resources/sanity-checks/db2-capture.yaml
@@ -1,0 +1,21 @@
+id: db2-capture
+namespace: sanitychecks.plugin-debezium-db2
+
+tasks:
+  - id: capture
+    type: io.kestra.plugin.debezium.db2.Capture
+    hostname: 127.0.0.1
+    port: "5023"
+    username: db2inst1
+    password: password
+    database: kestra
+    snapshotMode: INITIAL
+    maxRecords: 5
+    maxWait: PT30S
+    includedTables:
+      - DB2INST1.EVENTS
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.capture.size >= 5 }}"

--- a/plugin-debezium-mongodb/src/test/java/io/kestra/plugin/debezium/mongodb/SanityChecks.java
+++ b/plugin-debezium-mongodb/src/test/java/io/kestra/plugin/debezium/mongodb/SanityChecks.java
@@ -1,0 +1,23 @@
+package io.kestra.plugin.debezium.mongodb;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest(startRunner = true)
+@Disabled("Until there will be automatic way to execute mongo.js scripts")
+class SanityChecks {
+
+    @Test
+    @ExecuteFlow("sanity-checks/mongodb-capture.yaml")
+    void mongodbCapture(Execution execution) {
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+}

--- a/plugin-debezium-mongodb/src/test/resources/sanity-checks/mongodb-capture.yaml
+++ b/plugin-debezium-mongodb/src/test/resources/sanity-checks/mongodb-capture.yaml
@@ -1,0 +1,15 @@
+id: mongodb-capture
+namespace: sanitychecks.plugin-debezium-mongodb
+
+tasks:
+  - id: capture
+    type: io.kestra.plugin.debezium.mongodb.Capture
+    connectionString: mongodb://mongo_user:mongo_passwd@127.0.0.1:27017/?replicaSet=rs0
+    snapshotMode: INITIAL
+    maxRecords: 20
+    maxWait: PT30S
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.capture.size >= 20 }}"

--- a/plugin-debezium-mysql/src/test/java/io/kestra/plugin/debezium/mysql/SanityChecks.java
+++ b/plugin-debezium-mysql/src/test/java/io/kestra/plugin/debezium/mysql/SanityChecks.java
@@ -1,0 +1,57 @@
+package io.kestra.plugin.debezium.mysql;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.services.KVStoreService;
+import io.kestra.plugin.debezium.AbstractDebeziumTest;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest(startRunner = true)
+class SanityChecks extends AbstractDebeziumTest {
+
+    @Inject
+    private KVStoreService kvStoreService;
+
+    @Override
+    protected String getUrl() {
+        return "jdbc:mysql://127.0.0.1:63306/kestra";
+    }
+
+    @Override
+    protected String getUsername() {
+        return "root";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "mysql_passwd";
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        cleanupFlowState(kvStoreService, "sanitychecks.plugin-debezium-mysql", "mysql-capture", "debezium-state");
+        resetMaster();
+        executeSqlScript("scripts/mysql.sql");
+    }
+
+    private void resetMaster() throws Exception {
+        try (var connection = getConnection(); var statement = connection.createStatement()) {
+            statement.execute("RESET MASTER");
+        }
+    }
+
+    @Test
+    @ExecuteFlow("sanity-checks/mysql-capture.yaml")
+    void mysqlCapture(Execution execution) {
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+}

--- a/plugin-debezium-mysql/src/test/resources/sanity-checks/mysql-capture.yaml
+++ b/plugin-debezium-mysql/src/test/resources/sanity-checks/mysql-capture.yaml
@@ -1,0 +1,21 @@
+id: mysql-capture
+namespace: sanitychecks.plugin-debezium-mysql
+
+tasks:
+  - id: capture
+    type: io.kestra.plugin.debezium.mysql.Capture
+    serverId: 123456789
+    hostname: 127.0.0.1
+    port: "63306"
+    username: root
+    password: mysql_passwd
+    snapshotMode: NEVER
+    maxRecords: 5
+    maxWait: PT30S
+    includedTables:
+      - kestra.capture_events
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.capture.size >= 5 }}"

--- a/plugin-debezium-oracle/src/test/java/io/kestra/plugin/debezium/oracle/SanityChecks.java
+++ b/plugin-debezium-oracle/src/test/java/io/kestra/plugin/debezium/oracle/SanityChecks.java
@@ -1,0 +1,57 @@
+package io.kestra.plugin.debezium.oracle;
+
+import java.io.StringReader;
+
+import org.h2.tools.RunScript;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.services.KVStoreService;
+import io.kestra.plugin.debezium.AbstractDebeziumTest;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest(startRunner = true)
+class SanityChecks extends AbstractDebeziumTest {
+
+    @Inject
+    private KVStoreService kvStoreService;
+
+    @Override
+    protected String getUrl() {
+        return "jdbc:oracle:thin:@localhost:1521:XE";
+    }
+
+    @Override
+    protected String getUsername() {
+        return "kestra";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "passwd";
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        cleanupFlowState(kvStoreService, "sanitychecks.plugin-debezium-oracle", "oracle-capture", "debezium-state");
+        try {
+            RunScript.execute(getConnection(), new StringReader("DROP TABLE events"));
+        } catch (Exception ignored) {
+        }
+        executeSqlScript("scripts/oracle.sql");
+    }
+
+    @Test
+    @ExecuteFlow("sanity-checks/oracle-capture.yaml")
+    void oracleCapture(Execution execution) {
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+}

--- a/plugin-debezium-oracle/src/test/resources/sanity-checks/oracle-capture.yaml
+++ b/plugin-debezium-oracle/src/test/resources/sanity-checks/oracle-capture.yaml
@@ -1,0 +1,20 @@
+id: oracle-capture
+namespace: sanitychecks.plugin-debezium-oracle
+
+tasks:
+  - id: capture
+    type: io.kestra.plugin.debezium.oracle.Capture
+    hostname: 127.0.0.1
+    port: "1521"
+    username: c##dbzuser
+    password: dbz
+    sid: XE
+    snapshotMode: INITIAL_ONLY
+    maxRecords: 5
+    maxWait: PT30S
+    includedTables: KESTRA.EVENTS
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.capture.size >= 5 }}"

--- a/plugin-debezium-postgres/src/test/java/io/kestra/plugin/debezium/postgres/SanityChecks.java
+++ b/plugin-debezium-postgres/src/test/java/io/kestra/plugin/debezium/postgres/SanityChecks.java
@@ -1,0 +1,51 @@
+package io.kestra.plugin.debezium.postgres;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.services.KVStoreService;
+import io.kestra.plugin.debezium.AbstractDebeziumTest;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest(startRunner = true)
+class SanityChecks extends AbstractDebeziumTest {
+
+    @Inject
+    private KVStoreService kvStoreService;
+
+    @Override
+    protected String getUrl() {
+        return "jdbc:postgresql://127.0.0.1:65432/";
+    }
+
+    @Override
+    protected String getUsername() {
+        return TestUtils.username();
+    }
+
+    @Override
+    protected String getPassword() {
+        return TestUtils.password();
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        PostgresDebeziumTestHelper.dropReplicationArtifacts(this::getConnection, "kestra", "kestra_publication");
+        cleanupFlowState(kvStoreService, "sanitychecks.plugin-debezium-postgres", "postgres-capture", "debezium-state");
+        executeSqlScript("scripts/postgres.sql");
+    }
+
+    @Test
+    @ExecuteFlow("sanity-checks/postgres-capture.yaml")
+    void postgresCapture(Execution execution) {
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+}

--- a/plugin-debezium-postgres/src/test/resources/sanity-checks/postgres-capture.yaml
+++ b/plugin-debezium-postgres/src/test/resources/sanity-checks/postgres-capture.yaml
@@ -1,0 +1,21 @@
+id: postgres-capture
+namespace: sanitychecks.plugin-debezium-postgres
+
+tasks:
+  - id: capture
+    type: io.kestra.plugin.debezium.postgres.Capture
+    hostname: 127.0.0.1
+    port: "65432"
+    username: postgres
+    password: pg_passwd
+    database: postgres
+    snapshotMode: INITIAL
+    maxRecords: 5
+    maxWait: PT30S
+    includedTables:
+      - public.events
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.capture.size >= 5 }}"

--- a/plugin-debezium-sqlserver/src/test/java/io/kestra/plugin/debezium/sqlserver/SanityChecks.java
+++ b/plugin-debezium-sqlserver/src/test/java/io/kestra/plugin/debezium/sqlserver/SanityChecks.java
@@ -1,0 +1,50 @@
+package io.kestra.plugin.debezium.sqlserver;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.junit.annotations.ExecuteFlow;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.services.KVStoreService;
+import io.kestra.plugin.debezium.AbstractDebeziumTest;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KestraTest(startRunner = true)
+class SanityChecks extends AbstractDebeziumTest {
+
+    @Inject
+    private KVStoreService kvStoreService;
+
+    @Override
+    protected String getUrl() {
+        return "jdbc:sqlserver://localhost:61433;trustServerCertificate=true;databaseName=deb";
+    }
+
+    @Override
+    protected String getUsername() {
+        return "sa";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "Sqls3rv3r_Pa55word!";
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        cleanupFlowState(kvStoreService, "sanitychecks.plugin-debezium-sqlserver", "sqlserver-capture", "debezium-state");
+        executeSqlScript("scripts/sqlserver.sql");
+    }
+
+    @Test
+    @ExecuteFlow("sanity-checks/sqlserver-capture.yaml")
+    void sqlserverCapture(Execution execution) {
+        assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
+    }
+}

--- a/plugin-debezium-sqlserver/src/test/resources/sanity-checks/sqlserver-capture.yaml
+++ b/plugin-debezium-sqlserver/src/test/resources/sanity-checks/sqlserver-capture.yaml
@@ -1,0 +1,23 @@
+id: sqlserver-capture
+namespace: sanitychecks.plugin-debezium-sqlserver
+
+tasks:
+  - id: capture
+    type: io.kestra.plugin.debezium.sqlserver.Capture
+    hostname: 127.0.0.1
+    port: "61433"
+    username: sa
+    password: "Sqls3rv3r_Pa55word!"
+    database: deb
+    snapshotMode: INITIAL_ONLY
+    maxRecords: 5
+    maxWait: PT30S
+    includedTables:
+      - dbo.events
+    properties:
+      database.encrypt: "false"
+
+  - id: assert
+    type: io.kestra.plugin.core.execution.Assert
+    conditions:
+      - "{{ outputs.capture.size >= 5 }}"

--- a/plugin-debezium/src/test/java/io/kestra/plugin/debezium/AbstractDebeziumTest.java
+++ b/plugin-debezium/src/test/java/io/kestra/plugin/debezium/AbstractDebeziumTest.java
@@ -8,8 +8,15 @@ import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Objects;
 
+import io.kestra.core.services.KVStoreService;
+import io.kestra.core.storages.kv.KVEntry;
+import io.kestra.core.storages.kv.KVStore;
+import io.kestra.core.storages.kv.KVStoreException;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.Slugify;
 import org.h2.tools.RunScript;
 
 public abstract class AbstractDebeziumTest {
@@ -28,5 +35,27 @@ public abstract class AbstractDebeziumTest {
         URL url = Objects.requireNonNull(AbstractDebeziumTest.class.getClassLoader().getResource(path));
         FileReader fileReader = new FileReader(new File(url.toURI()));
         RunScript.execute(getConnection(), fileReader);
+    }
+
+    protected static void cleanupFlowState(KVStoreService kvStoreService, String namespace, String flowId, String... stateNames) throws Exception {
+        KVStore kvStore;
+        try {
+            kvStore = kvStoreService.get(TenantService.MAIN_TENANT, namespace, namespace);
+        } catch (KVStoreException e) {
+            return;
+        }
+
+        var flowPrefix = Slugify.of(flowId) + "_states_";
+        var keysToDelete = kvStore.listAll().stream()
+            .map(KVEntry::key)
+            .distinct()
+            .filter(key -> Arrays.stream(stateNames).anyMatch(stateName -> key.startsWith(flowPrefix + stateName)))
+            .toList();
+
+        for (var key : keysToDelete) {
+            while (kvStore.delete(key)) {
+                // Delete all versions to prevent fallback to stale previous entries.
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `@ExecuteFlow`-based `SanityChecks.java` and a `sanity-checks/<db>-capture.yaml` flow for each connector (Postgres, MySQL, SQLServer, Oracle, DB2, MongoDB), following the pattern established in `plugin-docker`
- Each flow runs a `Capture` task with an `Assert` step that validates `outputs.capture.size >= 5`
- DB2 and MongoDB sanity checks are `@Disabled` (matching their existing unit tests), all others are active
- Extract a shared `cleanupFlowState()` static helper into `AbstractDebeziumTest` so every `SanityChecks.java` can wipe stale Debezium KV state between runs without duplicating code

## Test plan

- [ ] Postgres: `@BeforeEach` drops replication slot/publication, cleans KV state, seeds `public.events`; flow asserts 5+ records captured via `INITIAL` snapshot
- [ ] MySQL: `@BeforeEach` cleans KV state, runs `RESET MASTER`, seeds `kestra.capture_events`; flow asserts 5+ records captured via `NEVER` (binlog-only) mode
- [ ] SQLServer: `@BeforeEach` cleans KV state, seeds `dbo.events`; flow asserts 5+ records captured via `INITIAL_ONLY` snapshot
- [ ] Oracle: `@BeforeEach` cleans KV state, drops and recreates `KESTRA.EVENTS`; flow asserts 5+ records captured via `INITIAL_ONLY` snapshot
- [ ] DB2: `@Disabled` (long container init time)
- [ ] MongoDB: `@Disabled` (no automated mongo.js execution)