### PR TITLE
refactor: replace deprecated tasks and filters

### DIFF
--- a/plugin-debezium-db2/src/test/resources/flows/realtime.yaml
+++ b/plugin-debezium-db2/src/test/resources/flows/realtime.yaml
@@ -16,5 +16,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-db2/src/test/resources/flows/trigger.yaml
+++ b/plugin-debezium-db2/src/test/resources/flows/trigger.yaml
@@ -17,5 +17,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-mongodb/src/test/resources/flows/realtime.yaml
+++ b/plugin-debezium-mongodb/src/test/resources/flows/realtime.yaml
@@ -11,5 +11,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-mongodb/src/test/resources/flows/trigger.yaml
+++ b/plugin-debezium-mongodb/src/test/resources/flows/trigger.yaml
@@ -10,5 +10,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-mysql/src/test/resources/flows/realtime.yaml
+++ b/plugin-debezium-mysql/src/test/resources/flows/realtime.yaml
@@ -17,5 +17,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-mysql/src/test/resources/flows/trigger.yaml
+++ b/plugin-debezium-mysql/src/test/resources/flows/trigger.yaml
@@ -20,5 +20,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-oracle/src/test/resources/flows/realtime.yaml
+++ b/plugin-debezium-oracle/src/test/resources/flows/realtime.yaml
@@ -15,5 +15,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-oracle/src/test/resources/flows/trigger.yaml
+++ b/plugin-debezium-oracle/src/test/resources/flows/trigger.yaml
@@ -15,5 +15,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-postgres/src/test/resources/flows/realtime.yaml
+++ b/plugin-debezium-postgres/src/test/resources/flows/realtime.yaml
@@ -15,5 +15,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-postgres/src/test/resources/flows/trigger.yaml
+++ b/plugin-debezium-postgres/src/test/resources/flows/trigger.yaml
@@ -16,5 +16,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-sqlserver/src/test/resources/flows/realtime.yaml
+++ b/plugin-debezium-sqlserver/src/test/resources/flows/realtime.yaml
@@ -19,5 +19,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-debezium-sqlserver/src/test/resources/flows/trigger.yaml
+++ b/plugin-debezium-sqlserver/src/test/resources/flows/trigger.yaml
@@ -20,5 +20,5 @@ triggers:
 
 tasks:
   - id: end
-    type: io.kestra.core.tasks.debugs.Return
+    type: io.kestra.plugin.core.debug.Return
     format: "{{task.id}} > {{taskrun.startDate}}"


### PR DESCRIPTION
Replaces deprecated task identifiers and Pebble filters with their current equivalents