### PR TITLE
fix(debezium): migrate legacy offset/history files to new connector id on first upgraded run

### DIFF
--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumRealtimeTrigger.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumRealtimeTrigger.java
@@ -140,6 +140,12 @@ public abstract class AbstractDebeziumRealtimeTrigger extends AbstractTrigger im
                     restoreStateFromKv(runContext, task, historyFile, DBHISTORY_DATA_FILE);
                 }
 
+                var connectorId = task.deriveConnectorId(runContext);
+                AbstractDebeziumTask.migrateOffsetFile(runContext.logger(), offsetFile, connectorId);
+                if (task.needDatabaseHistory()) {
+                    AbstractDebeziumTask.migrateHistoryFile(runContext.logger(), historyFile, connectorId);
+                }
+
                 final Properties props = task.properties(runContext, offsetFile, historyFile);
 
                 ChangeConsumer changeConsumer = new ChangeConsumer(task, runContext, new AtomicInteger(), null, ZonedDateTime.now(), offsetFile, historyFile);

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
@@ -4,7 +4,11 @@ import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -182,6 +186,12 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
             this.restoreState(runContext, historyFile);
         }
 
+        var connectorId = deriveConnectorId(runContext);
+        migrateOffsetFile(runContext.logger(), offsetFile, connectorId);
+        if (this.needDatabaseHistory()) {
+            migrateHistoryFile(runContext.logger(), historyFile, connectorId);
+        }
+
         final Properties props = this.properties(runContext, offsetFile, historyFile);
 
         ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
@@ -348,6 +358,133 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
         // enough for the expected cardinality of concurrent Kestra tasks.
         String hash = Hashing.hashToString(identity).substring(0, 8);
         return "kestra_" + hash;
+    }
+
+    // Pre-fix hardcoded values — the identity every existing offset file was written with.
+    static final String LEGACY_CONNECTOR_NAME = "engine";
+    static final String LEGACY_TOPIC_PREFIX = "kestra_";
+
+    /**
+     * Builds the compact JSON key that FileOffsetBackingStore stores in its HashMap.
+     * Format: ["<name>",{"server":"<topicPrefix>"}] — no spaces, as written by Kafka Connect.
+     */
+    static String offsetKey(String connectorName, String topicPrefix) {
+        return "[\"" + connectorName + "\",{\"server\":\"" + topicPrefix + "\"}]";
+    }
+
+    /**
+     * Rewrites the offset file so the derived connector id is the active key.
+     *
+     * Without this, upgrading from the hardcoded "engine"/"kestra_" identity to the new
+     * derived "kestra_<hex>" identity makes Debezium treat the run as a first-ever start
+     * (no matching offset found) and triggers a full re-snapshot of already-captured rows.
+     *
+     * Safe: wrapped in try/catch so any failure leaves the file untouched — worst case is
+     * the pre-existing re-snapshot behavior, not a new regression.
+     */
+    static void migrateOffsetFile(Logger logger, Path offsetFile, String newConnectorId) {
+        if (!offsetFile.toFile().exists() || offsetFile.toFile().length() == 0) {
+            return;
+        }
+
+        try {
+            HashMap<byte[], byte[]> offsets;
+            try (var ois = new ObjectInputStream(new FileInputStream(offsetFile.toFile()))) {
+                @SuppressWarnings("unchecked")
+                var loaded = (HashMap<byte[], byte[]>) ois.readObject();
+                offsets = loaded;
+            }
+
+            var newKey = offsetKey(newConnectorId, newConnectorId).getBytes(StandardCharsets.UTF_8);
+            var legacyKey = offsetKey(LEGACY_CONNECTOR_NAME, LEGACY_TOPIC_PREFIX).getBytes(StandardCharsets.UTF_8);
+
+            // Idempotency: new key already present means this run was already migrated or is native.
+            boolean alreadyMigrated = offsets.keySet().stream()
+                .anyMatch(k -> Arrays.equals(k, newKey));
+            if (alreadyMigrated) {
+                return;
+            }
+
+            // MongoDB uses a different partition shape (e.g. {"rs":"...", "server_id":"..."});
+            // its legacy offset key won't match LEGACY_CONNECTOR_NAME / LEGACY_TOPIC_PREFIX so
+            // this method is effectively a no-op for MongoDB — the file is left unchanged.
+            byte[] legacyValue = null;
+            byte[] legacyKeyInMap = null;
+            for (var entry : offsets.entrySet()) {
+                if (Arrays.equals(entry.getKey(), legacyKey)) {
+                    legacyValue = entry.getValue();
+                    legacyKeyInMap = entry.getKey();
+                    break;
+                }
+            }
+
+            if (legacyValue == null) {
+                return;
+            }
+
+            offsets.remove(legacyKeyInMap);
+            offsets.put(newKey, legacyValue);
+
+            try (var oos = new ObjectOutputStream(Files.newOutputStream(offsetFile))) {
+                oos.writeObject(offsets);
+            }
+
+            logger.info("Migrated legacy Debezium offset from connector 'engine' to '{}'", newConnectorId);
+        } catch (Exception e) {
+            logger.warn("Could not migrate legacy offset file; Debezium may re-snapshot (file left untouched): {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Rewrites the schema-history file (used by MySQL, Oracle, SQLServer, Db2) so that
+     * references to the legacy server name "kestra_" become the new derived connector id.
+     *
+     * FileSchemaHistory stores one JSON object per line; each record embeds the logical server
+     * name in its source/partition section. We do a targeted string replacement so that only
+     * the server-name token changes and the rest of each record is preserved verbatim.
+     *
+     * Best-effort: any line we cannot safely rewrite is left unchanged. Any I/O or parse
+     * failure leaves the file untouched.
+     */
+    static void migrateHistoryFile(Logger logger, Path historyFile, String newConnectorId) {
+        if (!historyFile.toFile().exists() || historyFile.toFile().length() == 0) {
+            return;
+        }
+
+        try {
+            var lines = Files.readAllLines(historyFile, StandardCharsets.UTF_8);
+
+            // Idempotency: if any line already references the new id, the file was already migrated.
+            boolean alreadyMigrated = lines.stream().anyMatch(l -> l.contains("\"" + newConnectorId + "\""));
+            if (alreadyMigrated) {
+                return;
+            }
+
+            // Replace "kestra_" server token with the new id in every line that contains it.
+            // We match the JSON string literal exactly to avoid touching unrelated content.
+            var legacyToken = "\"" + LEGACY_TOPIC_PREFIX + "\"";
+            var newToken = "\"" + newConnectorId + "\"";
+
+            boolean anyChanged = false;
+            var rewritten = new ArrayList<String>(lines.size());
+            for (var line : lines) {
+                if (line.contains(legacyToken)) {
+                    rewritten.add(line.replace(legacyToken, newToken));
+                    anyChanged = true;
+                } else {
+                    rewritten.add(line);
+                }
+            }
+
+            if (!anyChanged) {
+                return;
+            }
+
+            Files.write(historyFile, rewritten, StandardCharsets.UTF_8);
+            logger.info("Migrated legacy Debezium schema history from server 'kestra_' to '{}'", newConnectorId);
+        } catch (Exception e) {
+            logger.warn("Could not migrate legacy schema-history file; Debezium may re-snapshot (file left untouched): {}", e.getMessage());
+        }
     }
 
     protected Properties properties(RunContext runContext, Path offsetFile, Path historyFile) throws Exception {

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
@@ -34,6 +34,7 @@ import io.kestra.core.storages.kv.KVStore;
 import io.kestra.core.storages.kv.KVValue;
 import io.kestra.core.storages.kv.KVValueAndMetadata;
 import io.kestra.core.utils.Await;
+import io.kestra.core.utils.Hashing;
 
 import ch.qos.logback.classic.LoggerContext;
 import io.debezium.embedded.Connect;
@@ -290,10 +291,51 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
             .build();
     }
 
+    /**
+     * Derives a stable, unique connector identity scoped to this task's logical identity
+     * (namespace + flow + task, plus iteration value when inside a ForEach).
+     *
+     * The 8-character hex suffix (murmur3-128 truncated) keeps the identifier short and
+     * valid as a Debezium topic.prefix while guaranteeing uniqueness across concurrent
+     * connectors on the same JVM so their JMX MBean names never collide.
+     *
+     * The same value is used for `topic.prefix`, `name`, and `database.server.name` so all
+     * three remain consistent. A user-supplied `properties` map applied afterwards can still
+     * override any of these values.
+     */
+    static String deriveConnectorId(RunContext runContext) {
+        var flowInfo = runContext.flowInfo();
+        var taskRunInfo = runContext.taskRunInfo();
+
+        String namespace = flowInfo.namespace() != null ? flowInfo.namespace() : "";
+        String flowId = flowInfo.id() != null ? flowInfo.id() : "";
+        String taskId = taskRunInfo != null && taskRunInfo.taskId() != null ? taskRunInfo.taskId() : "";
+
+        // Include task-run value when present (ForEach / parallel iterations) to distinguish
+        // concurrently running iterations of the same task.
+        String iterationValue = taskRunInfo != null && taskRunInfo.value() != null ? taskRunInfo.value().toString() : "";
+
+        return connectorIdFromParts(namespace, flowId, taskId, iterationValue);
+    }
+
+    /**
+     * Pure function that computes the connector id from its constituent parts.
+     * Exposed package-private for unit testing without a full DI context.
+     */
+    static String connectorIdFromParts(String namespace, String flowId, String taskId, String iterationValue) {
+        String identity = namespace + "|" + flowId + "|" + taskId + "|" + iterationValue;
+        // Truncate to 8 hex chars (32 bits of murmur3-128) — short but collision-resistant
+        // enough for the expected cardinality of concurrent Kestra tasks.
+        String hash = Hashing.hashToString(identity).substring(0, 8);
+        return "kestra_" + hash;
+    }
+
     protected Properties properties(RunContext runContext, Path offsetFile, Path historyFile) throws Exception {
         final Properties props = new Properties();
 
-        props.setProperty("name", "engine");
+        var connectorId = deriveConnectorId(runContext);
+
+        props.setProperty("name", connectorId);
 
         // offset
         props.setProperty("offset.storage", "org.apache.kafka.connect.storage.FileOffsetBackingStore");
@@ -301,7 +343,7 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
         props.setProperty("offset.flush.interval.ms", "1000");
 
         // database
-        props.setProperty("database.server.name", "kestra");
+        props.setProperty("database.server.name", connectorId);
 
         if (this.needDatabaseHistory()) {
             props.setProperty("schema.history.internal", "io.debezium.storage.file.history.FileSchemaHistory");
@@ -332,8 +374,8 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
         // delete are send with a full rows, we don't want to emulate kafka behaviour
         props.setProperty("tombstones.on.delete", "false");
 
-        // required
-        props.setProperty("topic.prefix", "kestra_");
+        // required — use the same connector-unique id so JMX MBean names never collide
+        props.setProperty("topic.prefix", connectorId);
 
         if (this.includedDatabases != null) {
             props.setProperty("database.include.list", joinProperties(runContext, this.includedDatabases));

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
@@ -303,19 +303,39 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
      * three remain consistent. A user-supplied `properties` map applied afterwards can still
      * override any of these values.
      */
-    static String deriveConnectorId(RunContext runContext) {
+    String deriveConnectorId(RunContext runContext) {
         var flowInfo = runContext.flowInfo();
         var taskRunInfo = runContext.taskRunInfo();
 
         String namespace = flowInfo.namespace() != null ? flowInfo.namespace() : "";
         String flowId = flowInfo.id() != null ? flowInfo.id() : "";
-        String taskId = taskRunInfo != null && taskRunInfo.taskId() != null ? taskRunInfo.taskId() : "";
+
+        String taskRunTaskId = taskRunInfo != null ? taskRunInfo.taskId() : null;
+        String taskId = resolveTaskId(this.getId(), taskRunTaskId);
 
         // Include task-run value when present (ForEach / parallel iterations) to distinguish
         // concurrently running iterations of the same task.
         String iterationValue = taskRunInfo != null && taskRunInfo.value() != null ? taskRunInfo.value().toString() : "";
 
         return connectorIdFromParts(namespace, flowId, taskId, iterationValue);
+    }
+
+    /**
+     * Resolves the task component of the connector identity.
+     *
+     * Prefers the task/trigger's own id: it is always set, including during trigger
+     * evaluation where {@code taskRunInfo} is empty (no execution/taskrun exists yet).
+     * Without this, two distinct Debezium triggers in the same flow would derive the same
+     * id and their JMX MBeans would still collide. Falls back to the taskRunInfo task id,
+     * then to an empty string, only as a safety net.
+     *
+     * Exposed package-private for unit testing without a full DI context.
+     */
+    static String resolveTaskId(String ownId, String taskRunTaskId) {
+        if (ownId != null) {
+            return ownId;
+        }
+        return taskRunTaskId != null ? taskRunTaskId : "";
     }
 
     /**

--- a/plugin-debezium/src/test/java/io/kestra/plugin/debezium/ConnectorIdTest.java
+++ b/plugin-debezium/src/test/java/io/kestra/plugin/debezium/ConnectorIdTest.java
@@ -48,4 +48,32 @@ class ConnectorIdTest {
 
         assertThat(id1, is(not(id2)));
     }
+
+    @Test
+    void resolveTaskIdPrefersOwnId() {
+        // During trigger evaluation taskRunInfo is empty (no execution yet), so the
+        // task/trigger's own id is what keeps two triggers in the same flow distinct.
+        assertThat(AbstractDebeziumTask.resolveTaskId("my-trigger", null), is("my-trigger"));
+        // Own id always wins, even when taskRunInfo would also provide one.
+        assertThat(AbstractDebeziumTask.resolveTaskId("my-task", "taskrun-task-id"), is("my-task"));
+    }
+
+    @Test
+    void resolveTaskIdFallsBackWhenOwnIdMissing() {
+        assertThat(AbstractDebeziumTask.resolveTaskId(null, "taskrun-task-id"), is("taskrun-task-id"));
+        assertThat(AbstractDebeziumTask.resolveTaskId(null, null), is(""));
+    }
+
+    @Test
+    void distinctTriggersInSameFlowGetDistinctIds() {
+        // Two Debezium triggers in the same namespace/flow, differentiated only by their own
+        // id — this is the trigger-evaluation case where taskRunInfo is empty. They must not
+        // collide, otherwise their JMX MBean names would clash on the same JVM.
+        var triggerA = AbstractDebeziumTask.connectorIdFromParts(
+            "ns", "flow", AbstractDebeziumTask.resolveTaskId("trigger-a", null), "");
+        var triggerB = AbstractDebeziumTask.connectorIdFromParts(
+            "ns", "flow", AbstractDebeziumTask.resolveTaskId("trigger-b", null), "");
+
+        assertThat(triggerA, is(not(triggerB)));
+    }
 }

--- a/plugin-debezium/src/test/java/io/kestra/plugin/debezium/ConnectorIdTest.java
+++ b/plugin-debezium/src/test/java/io/kestra/plugin/debezium/ConnectorIdTest.java
@@ -1,0 +1,51 @@
+package io.kestra.plugin.debezium;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class ConnectorIdTest {
+
+    @Test
+    void derivedIdHasExpectedFormat() {
+        var id = AbstractDebeziumTask.connectorIdFromParts("my.namespace", "my-flow", "my-task", "");
+
+        assertThat(id, startsWith("kestra_"));
+        // "kestra_" (7 chars) + 8 hex chars = 15
+        assertThat(id.length(), is(15));
+        assertThat(id, matchesPattern("kestra_[0-9a-f]{8}"));
+    }
+
+    @Test
+    void sameInputsProduceSameId() {
+        var id1 = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", "task", "");
+        var id2 = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", "task", "");
+
+        assertThat(id1, is(id2));
+    }
+
+    @Test
+    void differentTaskIdsProduceDifferentIds() {
+        var id1 = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", "task-a", "");
+        var id2 = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", "task-b", "");
+
+        assertThat(id1, is(not(id2)));
+    }
+
+    @Test
+    void differentIterationValuesProduceDifferentIds() {
+        var id1 = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", "task", "iteration-1");
+        var id2 = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", "task", "iteration-2");
+
+        assertThat(id1, is(not(id2)));
+    }
+
+    @Test
+    void differentNamespacesProduceDifferentIds() {
+        var id1 = AbstractDebeziumTask.connectorIdFromParts("company.team-a", "flow", "task", "");
+        var id2 = AbstractDebeziumTask.connectorIdFromParts("company.team-b", "flow", "task", "");
+
+        assertThat(id1, is(not(id2)));
+    }
+}

--- a/plugin-debezium/src/test/java/io/kestra/plugin/debezium/OffsetMigrationTest.java
+++ b/plugin-debezium/src/test/java/io/kestra/plugin/debezium/OffsetMigrationTest.java
@@ -1,0 +1,291 @@
+package io.kestra.plugin.debezium;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kestra.core.utils.IdUtils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Pure unit tests for the legacy-offset migration logic.
+ * No Micronaut DI required — migration methods are static and only need a Logger.
+ */
+class OffsetMigrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(OffsetMigrationTest.class);
+
+    // ---------------------------------------------------------------------------
+    // offsetKey helper
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void offsetKeyFormat() {
+        assertThat(
+            AbstractDebeziumTask.offsetKey("engine", "kestra_"),
+            is("[\"engine\",{\"server\":\"kestra_\"}]")
+        );
+        assertThat(
+            AbstractDebeziumTask.offsetKey("kestra_b64777fd", "kestra_b64777fd"),
+            is("[\"kestra_b64777fd\",{\"server\":\"kestra_b64777fd\"}]")
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Offset file migration — happy path
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void migratesLegacyOffsetKeyToNewConnectorId(@TempDir Path tmp) throws Exception {
+        var offsetFile = tmp.resolve("offsets.dat");
+        var newId = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", IdUtils.create(), "");
+        var legacyValue = "{\"lsn\":12345,\"snapshot\":\"true\"}".getBytes(StandardCharsets.UTF_8);
+
+        writeOffsets(offsetFile, Map.of(
+            AbstractDebeziumTask.offsetKey(
+                AbstractDebeziumTask.LEGACY_CONNECTOR_NAME,
+                AbstractDebeziumTask.LEGACY_TOPIC_PREFIX
+            ),
+            legacyValue
+        ));
+
+        AbstractDebeziumTask.migrateOffsetFile(log, offsetFile, newId);
+
+        var result = readOffsets(offsetFile);
+        var expectedKey = AbstractDebeziumTask.offsetKey(newId, newId).getBytes(StandardCharsets.UTF_8);
+
+        assertThat("new key present", result.keySet().stream().anyMatch(k -> Arrays.equals(k, expectedKey)));
+        assertThat("legacy key removed", result.keySet().stream().noneMatch(k -> Arrays.equals(
+            k,
+            AbstractDebeziumTask.offsetKey(
+                AbstractDebeziumTask.LEGACY_CONNECTOR_NAME,
+                AbstractDebeziumTask.LEGACY_TOPIC_PREFIX
+            ).getBytes(StandardCharsets.UTF_8)
+        )));
+
+        byte[] migratedValue = result.entrySet().stream()
+            .filter(e -> Arrays.equals(e.getKey(), expectedKey))
+            .findFirst()
+            .map(Map.Entry::getValue)
+            .orElse(null);
+        assertThat("value is preserved unchanged", migratedValue, is(legacyValue));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Offset file migration — idempotency
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void idempotentWhenNewKeyAlreadyPresent(@TempDir Path tmp) throws Exception {
+        var offsetFile = tmp.resolve("offsets.dat");
+        var newId = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", IdUtils.create(), "");
+        var newKey = AbstractDebeziumTask.offsetKey(newId, newId);
+        var value = "{\"lsn\":99}".getBytes(StandardCharsets.UTF_8);
+
+        // File already has the new key — as if written by a post-fix run.
+        writeOffsets(offsetFile, Map.of(newKey, value));
+
+        var sizeBefore = Files.size(offsetFile);
+
+        AbstractDebeziumTask.migrateOffsetFile(log, offsetFile, newId);
+
+        // File must not have changed at all.
+        assertThat(Files.size(offsetFile), is(sizeBefore));
+        var result = readOffsets(offsetFile);
+        assertThat(result.size(), is(1));
+    }
+
+    @Test
+    void idempotentWhenRunTwice(@TempDir Path tmp) throws Exception {
+        var offsetFile = tmp.resolve("offsets.dat");
+        var newId = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", IdUtils.create(), "");
+        var legacyValue = "{\"lsn\":55}".getBytes(StandardCharsets.UTF_8);
+
+        writeOffsets(offsetFile, Map.of(
+            AbstractDebeziumTask.offsetKey(
+                AbstractDebeziumTask.LEGACY_CONNECTOR_NAME,
+                AbstractDebeziumTask.LEGACY_TOPIC_PREFIX
+            ),
+            legacyValue
+        ));
+
+        AbstractDebeziumTask.migrateOffsetFile(log, offsetFile, newId);
+        AbstractDebeziumTask.migrateOffsetFile(log, offsetFile, newId); // second call must be a no-op
+
+        var result = readOffsets(offsetFile);
+        assertThat(result.size(), is(1));
+
+        var expectedKey = AbstractDebeziumTask.offsetKey(newId, newId).getBytes(StandardCharsets.UTF_8);
+        assertThat("new key still present after second call",
+            result.keySet().stream().anyMatch(k -> Arrays.equals(k, expectedKey)));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Offset file migration — edge cases
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void noOpOnAbsentFile(@TempDir Path tmp) {
+        var offsetFile = tmp.resolve("absent.dat");
+
+        // Must not throw.
+        AbstractDebeziumTask.migrateOffsetFile(log, offsetFile, "kestra_aabbccdd");
+
+        assertThat(offsetFile.toFile().exists(), is(false));
+    }
+
+    @Test
+    void noOpOnEmptyFile(@TempDir Path tmp) throws Exception {
+        var offsetFile = tmp.resolve("empty.dat");
+        Files.createFile(offsetFile);
+
+        // Must not throw.
+        AbstractDebeziumTask.migrateOffsetFile(log, offsetFile, "kestra_aabbccdd");
+
+        assertThat(Files.size(offsetFile), is(0L));
+    }
+
+    @Test
+    void noThrowOnCorruptFile(@TempDir Path tmp) throws Exception {
+        var offsetFile = tmp.resolve("corrupt.dat");
+        Files.write(offsetFile, new byte[]{0x00, 0x01, 0x02, (byte) 0xFF});
+
+        // Must not throw — only log a warning.
+        AbstractDebeziumTask.migrateOffsetFile(log, offsetFile, "kestra_aabbccdd");
+
+        // File left untouched.
+        assertThat(Files.readAllBytes(offsetFile), is(new byte[]{0x00, 0x01, 0x02, (byte) 0xFF}));
+    }
+
+    @Test
+    void noOpWhenNoLegacyKeyPresent(@TempDir Path tmp) throws Exception {
+        // A file with an unknown/different key — simulates a MongoDB-style offset
+        // whose partition shape doesn't match the legacy JDBC key format.
+        var offsetFile = tmp.resolve("mongo.dat");
+        var mongoKey = "[\"kestra_cafe1234\",{\"rs\":\"rs0\",\"server_id\":\"kestra_cafe1234\"}]";
+        var mongoValue = "{\"sec\":1700000000,\"ord\":1}".getBytes(StandardCharsets.UTF_8);
+
+        writeOffsets(offsetFile, Map.of(mongoKey, mongoValue));
+        var sizeBefore = Files.size(offsetFile);
+
+        // The mongo-style key doesn't match the new key format, so the idempotency guard
+        // doesn't fire. The legacy-key scan also finds nothing and exits cleanly.
+        AbstractDebeziumTask.migrateOffsetFile(log, offsetFile, "kestra_cafe1234");
+
+        assertThat(Files.size(offsetFile), is(sizeBefore));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Schema-history file migration — happy path
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void migratesLegacyServerNameInHistoryFile(@TempDir Path tmp) throws Exception {
+        var historyFile = tmp.resolve("dbhistory.dat");
+        var newId = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", IdUtils.create(), "");
+
+        var lines = List.of(
+            "{\"source\":{\"server\":\"kestra_\"},\"position\":{\"ts_sec\":1000},\"databaseName\":\"mydb\",\"ddl\":\"CREATE TABLE t1 (id INT);\"}",
+            "{\"source\":{\"server\":\"kestra_\"},\"position\":{\"ts_sec\":1001},\"databaseName\":\"mydb\",\"ddl\":\"CREATE TABLE t2 (id INT);\"}"
+        );
+        Files.write(historyFile, lines, StandardCharsets.UTF_8);
+
+        AbstractDebeziumTask.migrateHistoryFile(log, historyFile, newId);
+
+        var result = Files.readAllLines(historyFile, StandardCharsets.UTF_8);
+        assertThat(result.size(), is(2));
+        for (var line : result) {
+            assertThat("new id in line", line.contains("\"" + newId + "\""));
+            assertThat("legacy token removed", !line.contains("\"kestra_\""));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Schema-history file migration — idempotency
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void historyMigrationIdempotentWhenNewIdAlreadyPresent(@TempDir Path tmp) throws Exception {
+        var historyFile = tmp.resolve("dbhistory.dat");
+        var newId = AbstractDebeziumTask.connectorIdFromParts("ns", "flow", IdUtils.create(), "");
+
+        var lines = List.of(
+            "{\"source\":{\"server\":\"" + newId + "\"},\"ddl\":\"CREATE TABLE t1 (id INT);\"}"
+        );
+        Files.write(historyFile, lines, StandardCharsets.UTF_8);
+        var contentBefore = Files.readString(historyFile, StandardCharsets.UTF_8);
+
+        AbstractDebeziumTask.migrateHistoryFile(log, historyFile, newId);
+
+        assertThat(Files.readString(historyFile, StandardCharsets.UTF_8), is(contentBefore));
+    }
+
+    @Test
+    void historyMigrationNoOpOnAbsentFile(@TempDir Path tmp) {
+        var historyFile = tmp.resolve("absent.dat");
+
+        AbstractDebeziumTask.migrateHistoryFile(log, historyFile, "kestra_aabbccdd");
+
+        assertThat(historyFile.toFile().exists(), is(false));
+    }
+
+    @Test
+    void historyMigrationNoOpOnEmptyFile(@TempDir Path tmp) throws Exception {
+        var historyFile = tmp.resolve("empty.dat");
+        Files.createFile(historyFile);
+
+        AbstractDebeziumTask.migrateHistoryFile(log, historyFile, "kestra_aabbccdd");
+
+        assertThat(Files.size(historyFile), is(0L));
+    }
+
+    @Test
+    void historyMigrationNoOpWhenNoLegacyToken(@TempDir Path tmp) throws Exception {
+        var historyFile = tmp.resolve("dbhistory.dat");
+        var line = "{\"source\":{\"server\":\"other_server\"},\"ddl\":\"CREATE TABLE t (id INT);\"}";
+        Files.write(historyFile, List.of(line), StandardCharsets.UTF_8);
+        var contentBefore = Files.readString(historyFile, StandardCharsets.UTF_8);
+
+        AbstractDebeziumTask.migrateHistoryFile(log, historyFile, "kestra_aabbccdd");
+
+        assertThat(Files.readString(historyFile, StandardCharsets.UTF_8), is(contentBefore));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /** Writes a HashMap<byte[],byte[]> in the same binary format as FileOffsetBackingStore. */
+    private static void writeOffsets(Path file, Map<String, byte[]> entries) throws IOException {
+        var map = new HashMap<byte[], byte[]>();
+        for (var e : entries.entrySet()) {
+            map.put(e.getKey().getBytes(StandardCharsets.UTF_8), e.getValue());
+        }
+        try (var oos = new ObjectOutputStream(new FileOutputStream(file.toFile()))) {
+            oos.writeObject(map);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static HashMap<byte[], byte[]> readOffsets(Path file) throws IOException, ClassNotFoundException {
+        try (var ois = new ObjectInputStream(new FileInputStream(file.toFile()))) {
+            return (HashMap<byte[], byte[]>) ois.readObject();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `migrateOffsetFile` and `migrateHistoryFile` as package-private static methods on `AbstractDebeziumTask`, called from both `run()` and `AbstractDebeziumRealtimeTrigger.publisher()` after state is restored from KV and before the Debezium engine starts.
- Pre-fix, offsets were stored under the hardcoded key `["engine",{"server":"kestra_"}]`. The new derived connector id (`kestra_<8hex>`) changes both `name` and `topic.prefix`, so Debezium cannot find the existing offset and triggers a full re-snapshot of already-captured rows.
- Migration rewrites the `FileOffsetBackingStore` binary HashMap (Java serialization) and the JSON-lines `FileSchemaHistory` in-place. Both are idempotent (skip if new key already present), never throw (log a warning and leave file untouched on any failure), and handle absent/empty/corrupt files gracefully.
- MongoDB is unaffected: its offset partition shape does not match the legacy JDBC key, so the scan finds nothing and exits early.

closes: https://github.com/kestra-io/plugin-debezium/issues/174

## Test plan

- [ ] `./gradlew :plugin-debezium:compileJava :plugin-debezium:compileTestJava` compiles cleanly
- [ ] `./gradlew :plugin-debezium:test` — `OffsetMigrationTest` (13 tests) passes: happy path, idempotency ×2, absent/empty/corrupt/non-legacy files, history migration happy path + idempotency + edge cases
- [ ] End-to-end: run a Postgres `Capture` task pre-fix, upgrade plugin JAR, rerun — no re-snapshot occurs and `runOutput.getSize()` is 0