### PR TITLE
fix(ci): stop "no space left on device" failures on main

### DIFF
--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -19,6 +19,11 @@
 # cp certs/client/* plugin-debezium-postgres/src/test/resources/ssl/
 # cp certs/ca.crt plugin-debezium-postgres/src/test/resources/ssl/
 
+# Reclaim runner disk before pulling the DB images. The CI runner only has ~14GB
+# free, and the combined database images previously filled it to 0MB, causing image
+# pulls to fail with "no space left on device".
+docker image prune -af || true
+
 docker compose -f docker-compose-ci.yml up -d mysql
 docker compose -f docker-compose-ci.yml up -d
 sleep 10

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -79,7 +79,7 @@ services:
 #      start_period: 240s
 
   oracle:
-    image: gvenzl/oracle-xe:21-full
+    image: gvenzl/oracle-xe:21-slim
     ports:
       - "1521:1521"
     environment:


### PR DESCRIPTION
## Problem

The scheduled `Main` CI on `main` failed ([run 27630606399](https://github.com/kestra-io/plugin-debezium/actions/runs/27630606399/job/81704263680)). The reported symptom looked like a heap issue, but the actual root cause is **disk exhaustion** on the runner:

- `16:00:20` — `docker run ... mcr.microsoft.com/mssql-tools` fails: `write /var/lib/docker/tmp/GetImageBlob...: no space left on device`, exit 125.
- `16:00:28` — `You are running out of disk space ... Free space left: 0 MB`.
- The `The maximum heap size is insufficient` Gradle line is **benign** — it's the standard notice that Gradle forks a single-use daemon to honour `-Xmx1g`, and it appears *after* the failure during post-job cache cleanup. No `OutOfMemoryError` exists in the log.

The `ubuntu-latest` runner has ~14 GB free; bringing up all five DB images at once (Oracle `21-full` alone is the largest) plus the restored Gradle caches fills it to 0 MB before the mssql-tools pull.

## Fix

- Switch Oracle to `gvenzl/oracle-xe:21-slim`. Verified locally: container boots healthy, both init scripts run with no `ORA-` errors, archivelog mode + supplemental logging + LogMiner tablespace are all set up — i.e. Debezium Oracle CDC requirements are intact.
- `docker image prune -af` in `setup-unit.sh` before bringing containers up, to reclaim dangling-image space on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)