### PR TITLE
docs(debezium): fix swapped column titles, wrong-DB copy-paste, and examples

### DIFF
--- a/plugin-debezium-db2/src/main/java/io/kestra/plugin/debezium/db2/Db2Interface.java
+++ b/plugin-debezium-db2/src/main/java/io/kestra/plugin/debezium/db2/Db2Interface.java
@@ -19,7 +19,7 @@ public interface Db2Interface {
         description = " Possible settings are:\n" +
             "- `ALWAYS`: The connector performs a snapshot every time that it starts.\n" +
             "- `INITIAL`: The connector runs a snapshot only when no offsets have been recorded for the logical server name.\n" +
-            "- `INITIAL_ONLY`: The connector runs a snapshot only when no offsets have been recorded for the logical server name and then stops; i.e. it will not read change events from the binlog.\n"
+            "- `INITIAL_ONLY`: The connector runs a snapshot only when no offsets have been recorded for the logical server name and then stops; i.e. it will not stream change events from the transaction log.\n"
             +
             "- `WHEN_NEEDED`: After the connector starts, it performs a snapshot only if it detects one of the following circumstances: 1. It cannot detect any topic offsets. 2. A previously recorded offset specifies a log position that is not available on the server.\n"
             +

--- a/plugin-debezium-mongodb/src/main/java/io/kestra/plugin/debezium/mongodb/Capture.java
+++ b/plugin-debezium-mongodb/src/main/java/io/kestra/plugin/debezium/mongodb/Capture.java
@@ -25,7 +25,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Wait for change data capture event on MongoDB server and capture the event as an internal storage file",
+    title = "Wait for a change data capture event on MongoDB server and capture the event as an internal storage file",
     description = "Streams change data capture (CDC) events from a MongoDB deployment using Debezium and writes them to Kestra's internal storage."
 )
 @Plugin(

--- a/plugin-debezium-mongodb/src/main/java/io/kestra/plugin/debezium/mongodb/MongodbInterface.java
+++ b/plugin-debezium-mongodb/src/main/java/io/kestra/plugin/debezium/mongodb/MongodbInterface.java
@@ -9,10 +9,10 @@ import jakarta.validation.constraints.NotNull;
 public interface MongodbInterface {
 
     @Schema(
-        title = "Defines connection string to mongodb replica set or sharded",
+        title = "Connection string to a MongoDB replica set or sharded cluster",
         examples = {
-            "mongodb://mongo_user:mongo_passwd@127.0.0.1:27017/?replicaSet=rs0",
-            "mongodb://mongo_user:mongo_passwd@mongos0.example.com:27017,mongos1.example.com:27017/"
+            "mongodb://mongo_user:<password>@127.0.0.1:27017/?replicaSet=rs0",
+            "mongodb://mongo_user:<password>@mongos0.example.com:27017,mongos1.example.com:27017/"
         }
     )
     @PluginProperty(group = "connection", secret = true)
@@ -38,11 +38,11 @@ public interface MongodbInterface {
         title = "Specifies the criteria for running a snapshot when the connector starts",
         description = " Possible settings are:\n" +
             "- `INITIAL`: The connector runs a snapshot only when no offsets have been recorded for the logical server name.\n" +
-            "- `INITIAL_ONLY`: The connector runs a snapshot only when no offsets have been recorded for the logical server name and then stops; i.e. it will not read change events from the binlog.\n"
+            "- `INITIAL_ONLY`: The connector runs a snapshot only when no offsets have been recorded for the logical server name and then stops; i.e. it will not stream change events from the oplog.\n"
             +
-            "- `NO_DATA`: The connector captures the structure of all relevant tables, performing all the steps described in the default snapshot workflow, except that it does not create READ events to represent the data set at the point of the connector’s start-up.\n"
+            "- `NO_DATA`: The connector captures the structure of all relevant collections, performing all the steps described in the default snapshot workflow, except that it does not create READ events to represent the data set at the point of the connector’s start-up.\n"
             +
-            "- `WHEN_NEEDED`: The connector runs a snapshot upon startup whenever it deems it necessary. That is, when no offsets are available, or when a previously recorded offset specifies a binlog location or GTID that is not available in the server."
+            "- `WHEN_NEEDED`: The connector runs a snapshot upon startup whenever it deems it necessary. That is, when no offsets are available, or when a previously recorded offset specifies an oplog position that is not available on the server."
     )
     @NotNull
     @PluginProperty(group = "main")

--- a/plugin-debezium-mongodb/src/main/resources/doc/io.kestra.plugin.debezium.mongodb.md
+++ b/plugin-debezium-mongodb/src/main/resources/doc/io.kestra.plugin.debezium.mongodb.md
@@ -10,8 +10,8 @@ Stream change data capture (CDC) events from MongoDB using [Debezium](https://de
 
 ## Connection
 
-Provide the MongoDB connection details (hostname, port, username, password, database) via [Kestra secrets](https://kestra.io/docs/concepts/secret) for credentials. MongoDB requires a replica set or sharded cluster with the oplog available.
+Provide the MongoDB `connectionString` (a replica-set or sharded-cluster URI, with credentials injected via [Kestra secrets](https://kestra.io/docs/concepts/secret)). MongoDB requires a replica set or sharded cluster with the oplog available.
 
 ## Notes
 
-Debezium tracks progress with an offset and database history stored under a state name, so a restarted task resumes from the last committed position rather than re-reading the whole log from the start.
+Debezium tracks progress with an offset stored under a state name, so a restarted task resumes from the last committed position rather than re-reading the whole log from the start.

--- a/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/Capture.java
+++ b/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/Capture.java
@@ -45,6 +45,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                     port: "3306"
                     username: "{{ secret('MYSQL_USERNAME') }}"
                     password: "{{ secret('MYSQL_PASSWORD') }}"
+                    serverId: "123456789"
                     maxRecords: 100
                 """
         )

--- a/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/Trigger.java
+++ b/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/Trigger.java
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Trigger a flow via a MySQL change data capture event periodically and create one execution per row",
+    title = "Trigger a flow via a MySQL change data capture event periodically and create one execution per batch",
     description = "If you would like to consume each message from change data capture in real-time and create one execution per message, you can use the [io.kestra.plugin.debezium.mysql.RealtimeTrigger](https://kestra.io/plugins/plugin-debezium/triggers/io.kestra.plugin.debezium.mysql.realtimetrigger) instead."
 )
 @Plugin(
@@ -44,7 +44,7 @@ import lombok.experimental.SuperBuilder;
 
                 triggers:
                   - id: trigger
-                    type: io.kestra.plugin.debezium.mysql.RealtimeTrigger
+                    type: io.kestra.plugin.debezium.mysql.Trigger
                     snapshotMode: NEVER
                     hostname: 127.0.0.1
                     port: "3306"

--- a/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/package-info.java
+++ b/plugin-debezium-mysql/src/main/java/io/kestra/plugin/debezium/mysql/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Debezium MySQL",
     description = "This sub-group of plugins contains tasks for using Debezium with MySQL.\n" +
         "Debezium is an open source distributed platform for change data capture.",
     categories = {

--- a/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/OracleInterface.java
+++ b/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/OracleInterface.java
@@ -27,9 +27,9 @@ public interface OracleInterface {
         description = " Possible settings are:\n" +
             "- `ALWAYS`: The connector runs a snapshot on each connector start.\n" +
             "- `INITIAL`: The connector runs a snapshot only when no offsets have been recorded for the logical server name.\n" +
-            "- `INITIAL_ONLY`: The connector runs a snapshot only when no offsets have been recorded for the logical server name and then stops; i.e. it will not read change events from the binlog.\n"
+            "- `INITIAL_ONLY`: The connector runs a snapshot only when no offsets have been recorded for the logical server name and then stops; i.e. it will not stream change events from the redo log.\n"
             +
-            "- `WHEN_NEEDED`: The connector runs a snapshot upon startup whenever it deems it necessary. That is, when no offsets are available, or when a previously recorded offset specifies a binlog location or GTID that is not available in the server.\n"
+            "- `WHEN_NEEDED`: The connector runs a snapshot upon startup whenever it deems it necessary. That is, when no offsets are available, or when a previously recorded offset specifies a redo log position (SCN) that is not available on the server.\n"
             +
             "- `NO_DATA`: The connector runs a snapshot of the schemas and not the data. This setting is useful when you do not need the topics to contain a consistent snapshot of the data but need them to have only the changes since the connector was started.\n"
             +

--- a/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/RealtimeTrigger.java
+++ b/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/RealtimeTrigger.java
@@ -28,7 +28,7 @@ import reactor.core.publisher.Flux;
 @Plugin(
     examples = {
         @Example(
-            title = "Consume a message from a Oracle database via change data capture in real-time.",
+            title = "Consume a message from an Oracle database via change data capture in real-time.",
             full = true,
             code = """
                 id: debezium_oracle

--- a/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/Trigger.java
+++ b/plugin-debezium-oracle/src/main/java/io/kestra/plugin/debezium/oracle/Trigger.java
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Trigger a flow via an Oracle change data capture event periodically and create one execution per row",
+    title = "Trigger a flow via an Oracle change data capture event periodically and create one execution per batch",
     description = "If you would like to consume each message from change data capture in real-time and create one execution per message, you can use the [io.kestra.plugin.debezium.oracle.RealtimeTrigger](https://kestra.io/plugins/plugin-debezium/triggers/io.kestra.plugin.debezium.oracle.realtimetrigger) instead."
 )
 @Plugin(

--- a/plugin-debezium-oracle/src/main/resources/doc/io.kestra.plugin.debezium.oracle.md
+++ b/plugin-debezium-oracle/src/main/resources/doc/io.kestra.plugin.debezium.oracle.md
@@ -10,7 +10,7 @@ Stream change data capture (CDC) events from Oracle using [Debezium](https://deb
 
 ## Connection
 
-Provide the Oracle connection details (hostname, port, username, password, database) via [Kestra secrets](https://kestra.io/docs/concepts/secret) for credentials. Oracle requires LogMiner or XStream access configured for CDC.
+Provide the Oracle connection details (hostname, port, username, password, `sid`, and an optional pluggable database) via [Kestra secrets](https://kestra.io/docs/concepts/secret) for credentials. Oracle requires LogMiner or XStream access configured for CDC.
 
 ## Notes
 

--- a/plugin-debezium-postgres/src/main/java/io/kestra/plugin/debezium/postgres/Trigger.java
+++ b/plugin-debezium-postgres/src/main/java/io/kestra/plugin/debezium/postgres/Trigger.java
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Trigger a flow via a PostgreSQL change data capture event periodically and create one execution per row",
+    title = "Trigger a flow via a PostgreSQL change data capture event periodically and create one execution per batch",
     description = "If you would like to consume each message from change data capture in real-time and create one execution per message, you can use the [io.kestra.plugin.debezium.postgres.RealtimeTrigger](https://kestra.io/plugins/plugin-debezium/triggers/io.kestra.plugin.debezium.postgres.realtimetrigger) instead."
 )
 @Plugin(

--- a/plugin-debezium-postgres/src/main/java/io/kestra/plugin/debezium/postgres/package-info.java
+++ b/plugin-debezium-postgres/src/main/java/io/kestra/plugin/debezium/postgres/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Debezium PostgreSQL",
     description = "This sub-group of plugins contains tasks for using Debezium with PostgreSQL.\n" +
         "Debezium is an open source distributed platform for change data capture.",
     categories = {

--- a/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/Capture.java
+++ b/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/Capture.java
@@ -32,17 +32,18 @@ import io.kestra.core.models.annotations.PluginProperty;
             title = "Wait for change data capture event on Microsoft SQL Server.",
             full = true,
             code = """
-                id: mysql_capture
+                id: sqlserver_capture
                 namespace: company.team
 
                 tasks:
                   - id: capture
-                    type: io.kestra.plugin.debezium.mysql.Capture
-                    snapshotMode: NEVER
+                    type: io.kestra.plugin.debezium.sqlserver.Capture
+                    snapshotMode: INITIAL
                     hostname: 127.0.0.1
-                    port: "3306"
-                    username: "{{ secret('MYSQL_USERNAME') }}"
-                    password: "{{ secret('MYSQL_PASSWORD') }}"
+                    port: "1433"
+                    username: "{{ secret('SQLSERVER_USERNAME') }}"
+                    password: "{{ secret('SQLSERVER_PASSWORD') }}"
+                    database: deb
                     maxRecords: 100
                 """
         )

--- a/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/RealtimeTrigger.java
+++ b/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/RealtimeTrigger.java
@@ -45,8 +45,8 @@ import reactor.core.publisher.Flux;
                     type: io.kestra.plugin.debezium.sqlserver.RealtimeTrigger
                     hostname: 127.0.0.1
                     port: "1433"
-                    username: "{{ secret('MYSQL_USERNAME') }}"
-                    password: "{{ secret('MYSQL_PASSWORD') }}"
+                    username: "{{ secret('SQLSERVER_USERNAME') }}"
+                    password: "{{ secret('SQLSERVER_PASSWORD') }}"
                     database: deb
                 """
         )

--- a/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/Trigger.java
+++ b/plugin-debezium-sqlserver/src/main/java/io/kestra/plugin/debezium/sqlserver/Trigger.java
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Trigger a flow via a SQL Server change data capture event periodically and create one execution per row",
+    title = "Trigger a flow via a SQL Server change data capture event periodically and create one execution per batch",
     description = "If you would like to consume each message from change data capture in real-time and create one execution per message, you can use the [io.kestra.plugin.debezium.sqlserver.RealtimeTrigger](https://kestra.io/plugins/plugin-debezium/triggers/io.kestra.plugin.debezium.sqlserver.realtimetrigger) instead."
 )
 @Plugin(
@@ -48,8 +48,8 @@ import lombok.experimental.SuperBuilder;
                     snapshotMode: INITIAL
                     hostname: 127.0.0.1
                     port: "1433"
-                    username: "{{ secret('MYSQL_USERNAME') }}"
-                    password: "{{ secret('MYSQL_PASSWORD') }}"
+                    username: "{{ secret('SQLSERVER_USERNAME') }}"
+                    password: "{{ secret('SQLSERVER_PASSWORD') }}"
                     database: deb
                     maxRecords: 100
                 """

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumInterface.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumInterface.java
@@ -11,8 +11,8 @@ import jakarta.validation.constraints.NotNull;
 public interface AbstractDebeziumInterface {
     @Schema(
         title = "The format of the output",
-        description = " Possible settings are:\n" +
-            "- `RAW`: Send raw data from debezium.\n" +
+        description = "Possible settings are:\n" +
+            "- `RAW`: Send raw data from Debezium.\n" +
             "- `INLINE`: Send a row like in the source with only data (remove after & before), all the columns will be present for each row.\n" +
             "- `WRAP`: Send a row like INLINE but wrapped in a `record` field.\n"
     )
@@ -21,7 +21,7 @@ public interface AbstractDebeziumInterface {
 
     @Schema(
         title = "Specify how to handle deleted rows",
-        description = " Possible settings are:\n" +
+        description = "Possible settings are:\n" +
             "- `ADD_FIELD`: Add a deleted field as boolean.\n" +
             "- `NULL`: Send a row with all values as null.\n" +
             "- `DROP`: Don't send deleted row."
@@ -38,7 +38,7 @@ public interface AbstractDebeziumInterface {
 
     @Schema(
         title = "Specify how to handle key",
-        description = " Possible settings are:\n" +
+        description = "Possible settings are:\n" +
             "- `ADD_FIELD`: Add key(s) merged with columns.\n" +
             "- `DROP`: Drop keys."
     )
@@ -47,7 +47,7 @@ public interface AbstractDebeziumInterface {
 
     @Schema(
         title = "Specify how to handle metadata",
-        description = " Possible settings are:\n" +
+        description = "Possible settings are:\n" +
             "- `ADD_FIELD`: Add metadata in a column named `metadata`.\n" +
             "- `DROP`: Drop metadata."
     )
@@ -63,7 +63,7 @@ public interface AbstractDebeziumInterface {
 
     @Schema(
         title = "Split table on separate output `uris`",
-        description = " Possible settings are:\n" +
+        description = "Possible settings are:\n" +
             "- `TABLE`: This will split all rows by tables on output with name `database.table`\n" +
             "- `DATABASE`: This will split all rows by databases on output with name `database`.\n" +
             "- `OFF`: This will **NOT** split all rows resulting in a single `data` output."
@@ -134,15 +134,15 @@ public interface AbstractDebeziumInterface {
     Object getExcludedTables();
 
     @Schema(
-        title = "An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event record values",
+        title = "An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to include in change event record values",
         description = "Fully-qualified names for columns are of the form databaseName.tableName.columnName. Do not also specify the `excludedColumns` connector configuration property."
     )
     @PluginProperty(dynamic = true, group = "advanced")
     Object getIncludedColumns();
 
     @Schema(
-        title = "An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to include in change event record values",
-        description = "Fully-qualified names for columns are of the form databaseName.tableName.columnName. Do not also specify the `includedColumns` connector configuration property.\""
+        title = "An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event record values",
+        description = "Fully-qualified names for columns are of the form databaseName.tableName.columnName. Do not also specify the `includedColumns` connector configuration property."
     )
     @PluginProperty(dynamic = true, group = "advanced")
     Object getExcludedColumns();

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTask.java
@@ -123,29 +123,29 @@ public abstract class AbstractDebeziumTask extends Task implements RunnableTask<
 
     @Schema(
         title = "The maximum number of rows to fetch before stopping",
-        description = "It's not an hard limit and is evaluated every second."
+        description = "It's not a hard limit and is evaluated every second."
     )
     @PluginProperty(group = "execution")
     private Property<Integer> maxRecords;
 
     @Schema(
         title = "The maximum duration waiting for new rows",
-        description = "It's not an hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
+        description = "It's not a hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
     )
     @PluginProperty(group = "execution")
     private Property<Duration> maxDuration;
 
     @Schema(
         title = "The maximum total processing duration",
-        description = "It's not an hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
+        description = "It's not a hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
     )
     @PluginProperty(group = "execution")
     @Builder.Default
     private Property<Duration> maxWait = Property.ofValue(Duration.ofSeconds(10));
 
     @Schema(
-        title = "The maximum duration waiting for the snapshot to ends",
-        description = "It's not an hard limit and is evaluated every second.\n The properties 'maxRecord', 'maxDuration' and 'maxWait' are evaluated only after the snapshot is done."
+        title = "The maximum duration waiting for the snapshot to end",
+        description = "It's not a hard limit and is evaluated every second.\n The properties 'maxRecords', 'maxDuration' and 'maxWait' are evaluated only after the snapshot is done."
     )
     @Builder.Default
     @PluginProperty(group = "execution")

--- a/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTrigger.java
+++ b/plugin-debezium/src/main/java/io/kestra/plugin/debezium/AbstractDebeziumTrigger.java
@@ -75,29 +75,29 @@ public abstract class AbstractDebeziumTrigger extends AbstractTrigger implements
 
     @Schema(
         title = "The maximum number of rows to fetch before stopping",
-        description = "It's not an hard limit and is evaluated every second."
+        description = "It's not a hard limit and is evaluated every second."
     )
     @PluginProperty(group = "execution")
     protected Property<Integer> maxRecords;
 
     @Schema(
         title = "The maximum duration waiting for new rows",
-        description = "It's not an hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
+        description = "It's not a hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
     )
     @PluginProperty(group = "execution")
     protected Property<Duration> maxDuration;
 
     @Schema(
         title = "The maximum total processing duration",
-        description = "It's not an hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
+        description = "It's not a hard limit and is evaluated every second.\n It is taken into account after the snapshot if any."
     )
     @Builder.Default
     @PluginProperty(group = "execution")
     protected Property<Duration> maxWait = Property.ofValue(Duration.ofSeconds(10));
 
     @Schema(
-        title = "The maximum duration waiting for the snapshot to ends",
-        description = "It's not an hard limit and is evaluated every second.\n The properties 'maxRecord', 'maxDuration' and 'maxWait' are evaluated only after the snapshot is done."
+        title = "The maximum duration waiting for the snapshot to end",
+        description = "It's not a hard limit and is evaluated every second.\n The properties 'maxRecords', 'maxDuration' and 'maxWait' are evaluated only after the snapshot is done."
     )
     @Builder.Default
     @PluginProperty(group = "execution")

--- a/plugin-debezium/src/main/resources/doc/io.kestra.plugin.debezium.md
+++ b/plugin-debezium/src/main/resources/doc/io.kestra.plugin.debezium.md
@@ -21,7 +21,7 @@ Each database connector requires one additional identifier:
 
 ## Tasks
 
-Each database has a `Capture` task that reads a bounded batch of change events and writes them to Kestra's internal storage. The output includes `size` (row count), `uris` (map of table name → file URI), `stateOffsetKey`, and `stateHistoryKey`.
+Each database has a `Capture` task that reads a bounded batch of change events and writes them to Kestra's internal storage. The output includes `size` (row count), `uris` (map of table name → file URI), and `stateOffsetKey`.
 
 ## Triggers
 


### PR DESCRIPTION
## Documentation review: plugin-debezium (multi-module)

Correctness/completeness pass across the core module and all 6 DB modules (mysql, postgres, oracle, mongodb, db2, sqlserver). Reviewed via 4 subagents (core + one per DB-module pair); registry-confirmed inventory (Capture + Trigger + RealtimeTrigger per DB). Documentation only; no runtime behavior changes. Code items are in the flag list.

### Core (renders on every DB task via the shared `AbstractDebeziumInterface`)
- **Swapped column titles** — `getIncludedColumns` title said "columns to **exclude**" and `getExcludedColumns` said "columns to **include**" (its own description confirms the swap). Fixed both.
- Removed a stray trailing `"` from the `excludedColumns` description; trimmed 5 leading spaces in enum descriptions; `debezium` → `Debezium`; grammar in `maxRecords`/`maxDuration`/`maxSnapshotDuration` ("an hard" → "a hard", "to ends" → "to end", `maxRecord` → `maxRecords`).
- Core how-to: dropped the **deprecated** `stateHistoryKey` from the documented `Capture` outputs.

### Wrong-DB copy-paste (snapshotMode enum descriptions)
The MySQL connector's "will not read change events from the **binlog**" / "binlog location or **GTID**" wording was copy-pasted into the other connectors' `snapshotMode` docs → corrected per engine: **Oracle** → redo log / SCN; **MongoDB** → oplog; **DB2** → transaction log. (`NO_DATA` on MongoDB also referenced "tables" → "collections".)

### SQL Server module (was the messiest)
- **`Capture` example** was a wholesale MySQL copy-paste: `id: mysql_capture`, `type: …mysql.Capture` (wrong FQCN), `snapshotMode: NEVER` (invalid for SQL Server), `port: "3306"`, `MYSQL_*` secrets, and the required `database` missing → fully rewritten (`…sqlserver.Capture`, `INITIAL`, `1433`, `SQLSERVER_*`, `database`).
- `Trigger`/`RealtimeTrigger` examples used `MYSQL_*` secret names → `SQLSERVER_*`.

### Batch `Trigger` titles
mysql/postgres/oracle/sqlserver batch `Trigger` titles said "…periodically and create one execution **per row**", but the batch trigger fires **once per poll batch** (db2/mongodb already said "per batch") → corrected all four.

### Per-module
- **mysql** — `Trigger` example declared `type: …mysql.RealtimeTrigger` in a batch-trigger example using `{{ trigger.uris }}` → `…mysql.Trigger`; `Capture` example omitted the required `serverId` → added; `package-info` given a subgroup title ("Debezium MySQL").
- **postgres** — `package-info` given a subgroup title ("Debezium PostgreSQL").
- **oracle** — `RealtimeTrigger` example title "a Oracle" → "an Oracle"; how-to connection line reworded to reference `sid` + optional pluggable database.
- **mongodb** — how-to said to provide "hostname, port, username, password, database" but the tasks only expose `connectionString` → corrected; dropped "database history" (MongoDB Capture sets `needDatabaseHistory()=false`); interface title "mongodb replica set or sharded" → "MongoDB replica set or sharded cluster"; plaintext `mongo_passwd` in the `@Schema` example → `<password>`; `Capture` title grammar.

Secret coverage is clean (username/password/connectionString are `secret = true`); the `records` metric is declared and emitted (verified); the `cloud/models` and core `Envelope`/`Message` DTOs are internal (no `@Schema` needed).

---

## 🚩 Engineering flag list (not addressed here — code changes)
- **SQL Server `serverId`** — `sqlserver.Trigger` and `RealtimeTrigger` declare and document a `serverId` property, but it's never passed to `Capture.builder()` and `Capture` has no `serverId` field (`server.id` is a MySQL-only concept). It's a documented no-op → remove it or wire it in.
- **`AbstractRun`-style selector** — n/a here (that was dbt); for debezium, **`Deleted.NULL`** is documented as "Send a row with all values as null", but `ChangeConsumer` only implements `ADD_FIELD` and `DROP` — `NULL` is neither filtered nor annotated. Verify or correct the enum doc.
- **Field-vs-interface group mismatches** — `mysql.Capture.serverId` (main vs interface advanced, and `@NotNull` only on Capture); `postgres.Capture` ssl* fields (advanced/connection vs interface connection); `oracle.Capture.snapshotMode` (advanced vs interface main).
- **`mongodb.Capture.includedCollections`/`excludedCollections`** fields lack the `@PluginProperty(dynamic = true, group = "advanced")` that the interface getters carry (field annotations don't inherit).