### PR TITLE
fix: register allure-results as a Test task output so it survives build-cache hits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,14 @@ subprojects {
 
     test {
         jvmArgs = [ "-javaagent:${configurations.agent.singleFile}" ]
+
+        // allure-junit5 writes results as a side effect of the test JVM, invisible to Gradle's
+        // dependency tracking. If Gradle build caching is ever enabled, a cache hit on :test
+        // would restore build/test-results/ but skip the JVM entirely, silently producing no
+        // allure-results for that run unless the directory is declared as a task output.
+        def allureResultsDir = layout.buildDirectory.dir("allure-results")
+        systemProperty 'allure.results.directory', allureResultsDir.get().asFile.absolutePath
+        outputs.dir(allureResultsDir)
     }
 }
 


### PR DESCRIPTION
## Summary
- Same underlying issue as kestra-io/plugin-scripts#405: `allure-junit5` writes its result JSONs as a side effect of the test JVM, invisible to Gradle's dependency tracking (not a declared `Test` task output).
- This repo doesn't currently set `org.gradle.caching=true`, so it isn't hit by this today, but the fix is cheap and future-proofs against a cache hit on `:test` silently producing an empty Allure report (JUnit XML would still be restored/reported correctly, masking the gap).
- Declares `build/allure-results` as an `outputs.dir(...)` of the `test` task and pins `allure.results.directory` there via system property, so a build-cache hit would restore it alongside the JUnit results.

## Test plan
- [x] `./gradlew help` — configuration phase parses cleanly.
- [x] `./gradlew :plugin-debezium:test` — ran live, produced 113 files under `plugin-debezium/build/allure-results/`.